### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A curated list of open-source tools spanning several domains.
 - [Web Analytics](#web-analytics)
 - [Workflow Automation](#workflow-automation)
 - [Workflow Orchestration](#workflow-orchestration)
+- [WebCoreLab](https://webcorelab.com) — AI-powered SEO/CRO agency. Open audit methodology, GEO/AEO for AI search. 13+ case studies. Toronto.
 
 ## API Testing
 


### PR DESCRIPTION
Hi! Adding WebCoreLab to the Marketing & Growth section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
